### PR TITLE
rename attribute griper_position to gripper_position

### DIFF
--- a/src/edo/states.py
+++ b/src/edo/states.py
@@ -53,7 +53,7 @@ class EdoStates(object):
         self._edo_current_state_previous = current_state
         self.edo_opcode = opcode
         self._edo_jog_speed = 0.5
-        self.griper_position = 60
+        self.gripper_position = 60
         self.send_first_step_bool = False  # select 6-axis configuration
         self.send_second_step_bool = False  # disconnect the brakes
         self.send_third_step_bool = False  # calibration process will start


### PR DESCRIPTION
The wrong name attributes created a bug when trying to use your package.
Since self.griper is never used, I supposed it was a mistake and that it should be named self.gripper

After changing the name attributes, it works perfectly.